### PR TITLE
feature: new `API` and `Proxy` methods

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3 # action page: <https://github.com/actions/setup-go>
+        uses: actions/setup-go@v4 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.19
+          go-version: stable
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.4.0 # Action page: <https://github.com/golangci/golangci-lint-action>
         with:
-          version: v1.50 # without patch version
+          version: v1.51 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --timeout=10m --build-tags=race

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/roadrunner-server/sdk/v4 v4.2.0
 	github.com/segmentio/encoding v0.3.6
 	github.com/stretchr/testify v1.8.2
-	go.buf.build/grpc/go/roadrunner-server/api v1.4.36
+	go.buf.build/grpc/go/roadrunner-server/api v1.4.38
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -83,10 +83,8 @@ github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYm
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.buf.build/grpc/go/roadrunner-server/api v1.4.32 h1:G3njz/qPYN4iTOJfAKJLMV6NF6a6Q+bl2o13fV+fkpQ=
-go.buf.build/grpc/go/roadrunner-server/api v1.4.32/go.mod h1:gydvLOEhY1OyTQFdpzBvDRn2QMpmtb73BSFFKu3JmPk=
-go.buf.build/grpc/go/roadrunner-server/api v1.4.36 h1:ZBS91rSnyXM8v+QkuidUU/yhlOBa69nJq/u2AZOnVEw=
-go.buf.build/grpc/go/roadrunner-server/api v1.4.36/go.mod h1:gydvLOEhY1OyTQFdpzBvDRn2QMpmtb73BSFFKu3JmPk=
+go.buf.build/grpc/go/roadrunner-server/api v1.4.38 h1:RPJFcwdeKUHo5lAXZ+aZGRSX4WKjbVfW7F7SSecUFw4=
+go.buf.build/grpc/go/roadrunner-server/api v1.4.38/go.mod h1:gydvLOEhY1OyTQFdpzBvDRn2QMpmtb73BSFFKu3JmPk=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
@@ -142,8 +140,6 @@ google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwS
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
-google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/rpc.go
+++ b/rpc.go
@@ -36,7 +36,129 @@ service CentrifugoApi {
     rpc RevokeToken (RevokeTokenRequest) returns (RevokeTokenResponse) {}
     rpc InvalidateUserTokens (InvalidateUserTokensRequest) returns (InvalidateUserTokensResponse) {}
 }
+
+// added in 2023.1
+service CentrifugoApi {
+  	rpc Batch(BatchRequest) returns (BatchResponse) {}
+  	rpc DeviceRegister(DeviceRegisterRequest) returns (DeviceRegisterResponse) {}
+  	rpc DeviceUpdate(DeviceUpdateRequest) returns (DeviceUpdateResponse) {}
+  	rpc DeviceRemove(DeviceRemoveRequest) returns (DeviceRemoveResponse) {}
+  	rpc DeviceList(DeviceListRequest) returns (DeviceListResponse) {}
+  	rpc PushUserChannelList(PushUserChannelListRequest) returns (PushUserChannelListResponse) {}
+  	rpc PushUserChannelUpdate(PushUserChannelUpdateRequest) returns (PushUserChannelUpdateResponse) {}
+  	rpc SendPushNotification(SendPushNotificationRequest) returns (SendPushNotificationResponse) {}
+}
 */
+
+func (r *rpc) SendPushNotification(in *v1Client.SendPushNotificationRequest, out *v1Client.SendPushNotificationResponse) error {
+	r.log.Debug("got send push notification request")
+
+	resp, err := r.client.client().SendPushNotification(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) PushUserChannelUpdate(in *v1Client.PushUserChannelUpdateRequest, out *v1Client.PushUserChannelUpdateResponse) error {
+	r.log.Debug("got device push user channel update request")
+
+	resp, err := r.client.client().PushUserChannelUpdate(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) PushUserChannelList(in *v1Client.PushUserChannelListRequest, out *v1Client.PushUserChannelListResponse) error {
+	r.log.Debug("got device push user channel list request")
+
+	resp, err := r.client.client().PushUserChannelList(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) DeviceList(in *v1Client.DeviceListRequest, out *v1Client.DeviceListResponse) error {
+	r.log.Debug("got device remove request")
+
+	resp, err := r.client.client().DeviceList(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) DeviceRemove(in *v1Client.DeviceRemoveRequest, out *v1Client.DeviceRemoveResponse) error {
+	r.log.Debug("got device remove request")
+
+	resp, err := r.client.client().DeviceRemove(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) DeviceUpdate(in *v1Client.DeviceUpdateRequest, out *v1Client.DeviceUpdateResponse) error {
+	r.log.Debug("got device update request")
+
+	resp, err := r.client.client().DeviceUpdate(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) DeviceRegister(in *v1Client.DeviceRegisterRequest, out *v1Client.DeviceRegisterResponse) error {
+	r.log.Debug("got device register request")
+
+	resp, err := r.client.client().DeviceRegister(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Error = resp.GetError()
+	out.Result = resp.GetResult()
+
+	return nil
+}
+
+func (r *rpc) Batch(in *v1Client.BatchRequest, out *v1Client.BatchResponse) error {
+	r.log.Debug("got butch request")
+
+	resp, err := r.client.client().Batch(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	out.Replies = resp.GetReplies()
+	return nil
+}
 
 func (r *rpc) Publish(in *v1Client.PublishRequest, out *v1Client.PublishResponse) error {
 	r.log.Debug("got publish request")


### PR DESCRIPTION
# Reason for This PR

ref: https://github.com/roadrunner-php/centrifugo/issues/6

## Description of Changes

Proxy:
```proto
service CentrifugoProxy {
        rpc SubRefresh(SubRefreshRequest) returns (SubRefreshResponse);
}
```

For the `SubRefresh` request RoadRunner will send a `subrefresh` request type in the metadata.

API:

```proto
service CentrifugoApi {
  	rpc Batch(BatchRequest) returns (BatchResponse) {}
  	rpc DeviceRegister(DeviceRegisterRequest) returns (DeviceRegisterResponse) {}
  	rpc DeviceUpdate(DeviceUpdateRequest) returns (DeviceUpdateResponse) {}
  	rpc DeviceRemove(DeviceRemoveRequest) returns (DeviceRemoveResponse) {}
  	rpc DeviceList(DeviceListRequest) returns (DeviceListResponse) {}
  	rpc PushUserChannelList(PushUserChannelListRequest) returns (PushUserChannelListResponse) {}
  	rpc PushUserChannelUpdate(PushUserChannelUpdateRequest) returns (PushUserChannelUpdateResponse) {}
  	rpc SendPushNotification(SendPushNotificationRequest) returns (SendPushNotificationResponse) {}
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
