### PR TITLE
feat/bug: Add JSON schema + add missing pool default init

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,8 +50,8 @@ func (c *Config) InitDefaults() error {
 
 	if c.Pool == nil {
 		c.Pool = &pool.Config{}
-		c.Pool.InitDefaults()
 	}
+	c.Pool.InitDefaults()
 
 	if c.TLS != nil { //nolint:nestif
 		if _, err := os.Stat(c.TLS.Key); err != nil {

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,56 @@
+{
+  "$id": "https://raw.githubusercontent.com/roadrunner-server/centrifuge/refs/heads/master/schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "description": "All the valid configuration parameters for the Centrifugo plugin for RoadRunner.",
+  "type": "object",
+  "title": "roadrunner-centrifuge",
+  "additionalProperties": false,
+  "properties": {
+    "proxy_address": {
+      "description": "The address of the Centrifugo proxy server.",
+      "type": "string",
+      "default": "tcp://127.0.0.1:30000"
+    },
+    "grpc_api_address": {
+      "description": "The address/port of the gRPC server API.",
+      "type": "string",
+      "default": "tcp://127.0.0.1:10000"
+    },
+    "use_compressor": {
+      "description": "Whether to use gRPC gzip compressor.",
+      "type": "boolean",
+      "default": false
+    },
+    "version": {
+      "description": "Your application version.",
+      "type": "string",
+      "default": "v1.0.0"
+    },
+    "name": {
+      "description": "Your application name.",
+      "type": "string",
+      "default": "roadrunner",
+      "minLength": 1
+    },
+    "pool": {
+      "$ref": "https://raw.githubusercontent.com/roadrunner-server/pool/refs/heads/master/schema.json"
+    },
+    "tls": {
+      "description": "TLS settings",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cert": {
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/http/refs/heads/master/schema.json#/$defs/SSL/properties/cert"
+        },
+        "key": {
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/http/refs/heads/master/schema.json#/$defs/SSL/properties/key"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ]
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -9,12 +9,14 @@
     "proxy_address": {
       "description": "The address of the Centrifugo proxy server.",
       "type": "string",
-      "default": "tcp://127.0.0.1:30000"
+      "default": "tcp://127.0.0.1:30000",
+      "minLength": 1
     },
     "grpc_api_address": {
       "description": "The address/port of the gRPC server API.",
       "type": "string",
-      "default": "tcp://127.0.0.1:10000"
+      "default": "tcp://127.0.0.1:10000",
+      "minLength": 1
     },
     "use_compressor": {
       "description": "Whether to use gRPC gzip compressor.",
@@ -24,7 +26,8 @@
     "version": {
       "description": "Your application version.",
       "type": "string",
-      "default": "v1.0.0"
+      "default": "v1.0.0",
+      "minLength": 1
     },
     "name": {
       "description": "Your application name.",


### PR DESCRIPTION
fix missing pool default init

# Reason for This PR

Added JSON schema.
Pool did not have its defaults set if you provided partial values.

## Description of Changes

Added JSON schema.
Moved `c.Pool.InitDefaults()` outside the init method.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a JSON schema for the Centrifugo plugin, defining required configuration parameters.
	- Added support for TLS settings within the schema, ensuring proper configuration for secure connections.

- **Bug Fixes**
	- Updated the initialization logic for the Pool configuration to ensure defaults are always set correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->