### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,6 +58,9 @@ jobs:
           cd tests
           mkdir ./coverage-ci
           go test -timeout 20m -v -race -cover -tags=debug -failfast -coverpkg=github.com/roadrunner-server/centrifuge/v6/... -coverprofile=./coverage-ci/centrifuge.out -covermode=atomic ./...
+      - name: Run unit tests with coverage
+        run: |
+          go test -timeout 5m -race -coverpkg=github.com/roadrunner-server/centrifuge/v6/... -coverprofile=./tests/coverage-ci/unit.out -covermode=atomic github.com/roadrunner-server/centrifuge/v6
       - name: Archive code coverage results
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,10 +56,11 @@ jobs:
       - name: Run golang tests with coverage
         run: |
           cd tests
-          mkdir ./coverage-ci
+          mkdir -p ./coverage-ci
           go test -timeout 20m -v -race -cover -tags=debug -failfast -coverpkg=github.com/roadrunner-server/centrifuge/v6/... -coverprofile=./coverage-ci/centrifuge.out -covermode=atomic ./...
       - name: Run unit tests with coverage
         run: |
+          mkdir -p ./tests/coverage-ci
           go test -timeout 5m -race -coverpkg=github.com/roadrunner-server/centrifuge/v6/... -coverprofile=./tests/coverage-ci/unit.out -covermode=atomic github.com/roadrunner-server/centrifuge/v6
       - name: Archive code coverage results
         uses: actions/upload-artifact@v7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 60%

--- a/config.go
+++ b/config.go
@@ -1,7 +1,9 @@
 package centrifuge
 
 import (
+	stderrors "errors"
 	"os"
+	"strings"
 
 	"github.com/roadrunner-server/errors"
 	"github.com/roadrunner-server/pool/v2/pool"
@@ -32,8 +34,8 @@ func (c *Config) InitDefaults() error {
 		c.GrpcAPIAddress = "127.0.0.1:10000"
 	}
 
-	if len(c.GrpcAPIAddress) > 7 && c.GrpcAPIAddress[0:6] == "tcp://" {
-		c.GrpcAPIAddress = c.GrpcAPIAddress[6:]
+	if addr, ok := strings.CutPrefix(c.GrpcAPIAddress, "tcp://"); ok {
+		c.GrpcAPIAddress = addr
 	}
 
 	if c.ProxyAddress == "" {
@@ -55,7 +57,7 @@ func (c *Config) InitDefaults() error {
 
 	if c.TLS != nil { //nolint:nestif
 		if _, err := os.Stat(c.TLS.Key); err != nil {
-			if os.IsNotExist(err) {
+			if stderrors.Is(err, os.ErrNotExist) {
 				return errors.E(op, errors.Errorf("key file '%s' does not exists", c.TLS.Key))
 			}
 
@@ -63,7 +65,7 @@ func (c *Config) InitDefaults() error {
 		}
 
 		if _, err := os.Stat(c.TLS.Cert); err != nil {
-			if os.IsNotExist(err) {
+			if stderrors.Is(err, os.ErrNotExist) {
 				return errors.E(op, errors.Errorf("cert file '%s' does not exists", c.TLS.Cert))
 			}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,9 +1,12 @@
 package centrifuge
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGrpcConfig(t *testing.T) {
@@ -34,4 +37,63 @@ func TestGrpcConfig2(t *testing.T) {
 	}
 
 	assert.Equal(t, "tcp:/foo.bar", cfg.GrpcAPIAddress)
+}
+
+// TestGrpcConfigShortPrefix guards the off-by-one fixed by strings.CutPrefix:
+// "tcp://x" is exactly 7 chars, which the old `len > 7 && addr[0:6] == "tcp://"`
+// check skipped, leaving the scheme in place.
+func TestGrpcConfigShortPrefix(t *testing.T) {
+	cfg := &Config{GrpcAPIAddress: "tcp://x"}
+	require.NoError(t, cfg.InitDefaults())
+
+	assert.Equal(t, "x", cfg.GrpcAPIAddress)
+}
+
+func TestConfigDefaults(t *testing.T) {
+	cfg := &Config{}
+	require.NoError(t, cfg.InitDefaults())
+
+	assert.Equal(t, "127.0.0.1:10000", cfg.GrpcAPIAddress)
+	assert.Equal(t, "tcp://127.0.0.1:30000", cfg.ProxyAddress)
+	assert.Equal(t, "roadrunner", cfg.Name)
+	assert.Equal(t, "1.0.0", cfg.Version)
+	assert.NotNil(t, cfg.Pool)
+}
+
+func TestConfigTLSMissingKey(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{TLS: &TLS{
+		Key:  filepath.Join(dir, "absent.key"),
+		Cert: filepath.Join(dir, "absent.cert"),
+	}}
+
+	err := cfg.InitDefaults()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key file")
+	assert.Contains(t, err.Error(), "does not exists")
+}
+
+func TestConfigTLSMissingCert(t *testing.T) {
+	dir := t.TempDir()
+	key := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(key, []byte("x"), 0o600))
+
+	cfg := &Config{TLS: &TLS{Key: key, Cert: filepath.Join(dir, "absent.cert")}}
+
+	err := cfg.InitDefaults()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cert file")
+	assert.Contains(t, err.Error(), "does not exists")
+}
+
+func TestConfigTLSValid(t *testing.T) {
+	dir := t.TempDir()
+	key := filepath.Join(dir, "tls.key")
+	cert := filepath.Join(dir, "tls.cert")
+	require.NoError(t, os.WriteFile(key, []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(cert, []byte("x"), 0o600))
+
+	cfg := &Config{TLS: &TLS{Key: key, Cert: cert}}
+
+	require.NoError(t, cfg.InitDefaults())
 }

--- a/metrics.go
+++ b/metrics.go
@@ -68,14 +68,14 @@ func (s *StatsExporter) Collect(ch chan<- prometheus.Metric) {
 	var invalid float64
 
 	// collect the memory
-	for i := range workerStates {
-		cum += float64(workerStates[i].MemoryUsage)
+	for _, ws := range workerStates {
+		cum += float64(ws.MemoryUsage)
 
-		ch <- prometheus.MustNewConstMetric(s.StateDesc, prometheus.GaugeValue, 0, workerStates[i].StatusStr, strconv.Itoa(int(workerStates[i].Pid)))
-		ch <- prometheus.MustNewConstMetric(s.WorkerMemoryDesc, prometheus.GaugeValue, float64(workerStates[i].MemoryUsage), strconv.Itoa(int(workerStates[i].Pid)))
+		ch <- prometheus.MustNewConstMetric(s.StateDesc, prometheus.GaugeValue, 0, ws.StatusStr, strconv.Itoa(int(ws.Pid)))
+		ch <- prometheus.MustNewConstMetric(s.WorkerMemoryDesc, prometheus.GaugeValue, float64(ws.MemoryUsage), strconv.Itoa(int(ws.Pid)))
 
 		// sync with sdk/worker/state.go
-		switch workerStates[i].Status {
+		switch ws.Status {
 		case fsm.StateReady:
 			ready++
 		case fsm.StateWorking:

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,74 @@
+package centrifuge
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/roadrunner-server/pool/v2/fsm"
+	"github.com/roadrunner-server/pool/v2/state/process"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeInformer struct {
+	states []*process.State
+}
+
+func (f *fakeInformer) Workers() []*process.State { return f.states }
+
+// collectCount registers exp in a fresh registry and returns the number of
+// gathered samples. Gather rejects duplicate label sets, which is why the
+// states below must carry distinct PIDs.
+func collectCount(t *testing.T, exp *StatsExporter) int {
+	t.Helper()
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(exp))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	var n int
+	for _, mf := range mfs {
+		n += len(mf.GetMetric())
+	}
+
+	return n
+}
+
+func TestStatsExporterCollect(t *testing.T) {
+	// Distinct PIDs avoid duplicate label sets; the three statuses also cover the
+	// ready/working/default arms of the status switch in Collect.
+	inf := &fakeInformer{states: []*process.State{
+		{Pid: 1, Status: fsm.StateReady, StatusStr: "ready", MemoryUsage: 100},
+		{Pid: 2, Status: fsm.StateWorking, StatusStr: "working", MemoryUsage: 200},
+		{Pid: 3, Status: fsm.StateInactive, StatusStr: "inactive", MemoryUsage: 300},
+	}}
+
+	// 2 per-worker series (state + memory) plus 5 aggregate series.
+	require.Equal(t, 2*len(inf.states)+5, collectCount(t, newWorkersExporter(inf)))
+}
+
+func TestStatsExporterCollectEmpty(t *testing.T) {
+	require.Equal(t, 5, collectCount(t, newWorkersExporter(&fakeInformer{})))
+}
+
+func TestStatsExporterDescribe(t *testing.T) {
+	exp := newWorkersExporter(&fakeInformer{})
+
+	ch := make(chan *prometheus.Desc, 16)
+	exp.Describe(ch)
+	close(ch)
+
+	var n int
+	for range ch {
+		n++
+	}
+
+	require.Equal(t, 7, n)
+}
+
+func TestPluginMetricsCollector(t *testing.T) {
+	p := &Plugin{statsExporter: newWorkersExporter(&fakeInformer{})}
+
+	require.Len(t, p.MetricsCollector(), 1)
+}

--- a/plugin.go
+++ b/plugin.go
@@ -89,7 +89,7 @@ func (p *Plugin) Init(cfg Configurer, log Logger, server Server) error {
 
 	p.log = log.NamedLogger(name)
 	p.server = server
-	// nosemgrep
+	// nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 	p.gRPCServer = grpc.NewServer()
 	p.client = newClient(p.cfg.GrpcAPIAddress, p.cfg.TLS, p.log, p.cfg.UseCompressor)
 	p.statsExporter = newWorkersExporter(p)
@@ -154,7 +154,9 @@ func (p *Plugin) Stop(ctx context.Context) error {
 	go func() {
 		p.mu.Lock()
 		p.gRPCServer.GracefulStop()
-		p.pool.Destroy(ctx)
+		if p.pool != nil {
+			p.pool.Destroy(ctx)
+		}
 		p.mu.Unlock()
 		stCh <- struct{}{}
 	}()
@@ -179,8 +181,8 @@ func (p *Plugin) Workers() []*process.State {
 
 	ps := make([]*process.State, 0, len(workers))
 
-	for i := range workers {
-		state, err := process.WorkerProcessState(workers[i])
+	for _, w := range workers {
+		state, err := process.WorkerProcessState(w)
 		if err != nil {
 			return nil
 		}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,38 @@
+package centrifuge
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// testLogger returns a no-op slog logger shared across the package's unit tests.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPluginStopNilPool(t *testing.T) {
+	// pool is nil when Serve returned early; Stop must not panic on Destroy.
+	p := &Plugin{gRPCServer: grpc.NewServer()}
+
+	var err error
+	require.NotPanics(t, func() { err = p.Stop(context.Background()) })
+	require.NoError(t, err)
+}
+
+func TestPluginWorkersNilPool(t *testing.T) {
+	p := &Plugin{}
+
+	assert.Nil(t, p.Workers())
+}
+
+func TestPluginResetNilPool(t *testing.T) {
+	p := &Plugin{log: testLogger()}
+
+	require.NoError(t, p.Reset())
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,7 +1,6 @@
 package centrifuge
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"testing"
@@ -21,7 +20,7 @@ func TestPluginStopNilPool(t *testing.T) {
 	p := &Plugin{gRPCServer: grpc.NewServer()}
 
 	var err error
-	require.NotPanics(t, func() { err = p.Stop(context.Background()) })
+	require.NotPanics(t, func() { err = p.Stop(t.Context()) })
 	require.NoError(t, err)
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -27,7 +27,10 @@ func (p *Proxy) Connect(ctx context.Context, request *centrifugov1.ConnectReques
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "connect")
 
 	meta, err := json.Marshal(md)
@@ -64,7 +67,10 @@ func (p *Proxy) Refresh(ctx context.Context, request *centrifugov1.RefreshReques
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "refresh")
 
 	meta, err := json.Marshal(md)
@@ -102,7 +108,10 @@ func (p *Proxy) Subscribe(ctx context.Context, request *centrifugov1.SubscribeRe
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "subscribe")
 
 	meta, err := json.Marshal(md)
@@ -140,7 +149,10 @@ func (p *Proxy) Publish(ctx context.Context, request *centrifugov1.PublishReques
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "publish")
 
 	meta, err := json.Marshal(md)
@@ -178,7 +190,10 @@ func (p *Proxy) RPC(ctx context.Context, request *centrifugov1.RPCRequest) (*cen
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "rpc")
 
 	meta, err := json.Marshal(md)
@@ -216,7 +231,10 @@ func (p *Proxy) SubRefresh(ctx context.Context, request *centrifugov1.SubRefresh
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "subrefresh")
 
 	meta, err := json.Marshal(md)
@@ -254,7 +272,10 @@ func (p *Proxy) NotifyCacheEmpty(ctx context.Context, request *centrifugov1.Noti
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "notifycacheempty")
 
 	meta, err := json.Marshal(md)
@@ -292,7 +313,10 @@ func (p *Proxy) NotifyChannelState(ctx context.Context, request *centrifugov1.No
 		return nil, err
 	}
 
-	md, _ := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
 	md.Append("type", "notifychannelstate")
 
 	meta, err := json.Marshal(md)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,91 @@
+package centrifuge
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	centrifugov1 "github.com/roadrunner-server/api-go/v6/centrifugo/proxy/v1"
+	"github.com/roadrunner-server/pool/v2/payload"
+	staticPool "github.com/roadrunner-server/pool/v2/pool/static_pool"
+	"github.com/roadrunner-server/pool/v2/worker"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+// fakePool implements the Pool interface. Exec always returns an error so each
+// proxy method exits right after the gRPC-metadata guard block (the lines under
+// test); staticPool.PExec cannot be constructed outside its package, so a
+// success path is not reproducible here.
+type fakePool struct {
+	execErr error
+}
+
+func (f *fakePool) Workers() []*worker.Process           { return nil }
+func (f *fakePool) RemoveWorker(_ context.Context) error { return nil }
+func (f *fakePool) AddWorker() error                     { return nil }
+func (f *fakePool) Reset(_ context.Context) error        { return nil }
+func (f *fakePool) Destroy(_ context.Context)            {}
+
+func (f *fakePool) Exec(_ context.Context, _ *payload.Payload, _ chan struct{}) (chan *staticPool.PExec, error) {
+	return nil, f.execErr
+}
+
+func newTestProxy() *Proxy {
+	return &Proxy{
+		log: testLogger(),
+		pw:  newPoolMuWrapper(&fakePool{execErr: errors.New("exec failed")}, &sync.RWMutex{}),
+	}
+}
+
+// TestProxyMethodsMetadataGuard exercises every proxy handler with and without
+// incoming gRPC metadata. The no-metadata case is the regression guard: the old
+// discarded-ok pattern left md as a nil map, so md.Append panicked on every
+// unauthenticated call.
+func TestProxyMethodsMetadataGuard(t *testing.T) {
+	p := newTestProxy()
+
+	calls := map[string]func(context.Context) error{
+		"Connect": func(ctx context.Context) error { _, err := p.Connect(ctx, &centrifugov1.ConnectRequest{}); return err },
+		"Refresh": func(ctx context.Context) error { _, err := p.Refresh(ctx, &centrifugov1.RefreshRequest{}); return err },
+		"Subscribe": func(ctx context.Context) error {
+			_, err := p.Subscribe(ctx, &centrifugov1.SubscribeRequest{})
+			return err
+		},
+		"Publish": func(ctx context.Context) error { _, err := p.Publish(ctx, &centrifugov1.PublishRequest{}); return err },
+		"RPC":     func(ctx context.Context) error { _, err := p.RPC(ctx, &centrifugov1.RPCRequest{}); return err },
+		"SubRefresh": func(ctx context.Context) error {
+			_, err := p.SubRefresh(ctx, &centrifugov1.SubRefreshRequest{})
+			return err
+		},
+		"NotifyCacheEmpty": func(ctx context.Context) error {
+			_, err := p.NotifyCacheEmpty(ctx, &centrifugov1.NotifyCacheEmptyRequest{})
+			return err
+		},
+		"NotifyChannelState": func(ctx context.Context) error {
+			_, err := p.NotifyChannelState(ctx, &centrifugov1.NotifyChannelStateRequest{})
+			return err
+		},
+	}
+
+	ctxNoMD := context.Background()
+	ctxWithMD := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "bearer x"))
+
+	for name, call := range calls {
+		var err error
+
+		require.NotPanics(t, func() { err = call(ctxNoMD) }, "%s panicked without incoming metadata", name)
+		require.Error(t, err, "%s: expected error from failing Exec (no metadata)", name)
+
+		require.NotPanics(t, func() { err = call(ctxWithMD) }, "%s panicked with incoming metadata", name)
+		require.Error(t, err, "%s: expected error from failing Exec (with metadata)", name)
+	}
+}
+
+func TestProxyStreamingNotSupported(t *testing.T) {
+	p := newTestProxy()
+
+	require.Error(t, p.SubscribeUnidirectional(&centrifugov1.SubscribeRequest{}, nil))
+	require.Error(t, p.SubscribeBidirectional(nil))
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -69,8 +69,8 @@ func TestProxyMethodsMetadataGuard(t *testing.T) {
 		},
 	}
 
-	ctxNoMD := context.Background()
-	ctxWithMD := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "bearer x"))
+	ctxNoMD := t.Context()
+	ctxWithMD := metadata.NewIncomingContext(t.Context(), metadata.Pairs("authorization", "bearer x"))
 
 	for name, call := range calls {
 		var err error

--- a/rpc.go
+++ b/rpc.go
@@ -53,7 +53,7 @@ service CentrifugoApi {
 */
 
 func (r *rpc) Batch(in *v1Client.BatchRequest, out *v1Client.BatchResponse) error {
-	r.log.Debug("got butch request")
+	r.log.Debug("got batch request")
 
 	client := r.client.client()
 	if client == nil {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1,0 +1,18 @@
+package centrifuge
+
+import (
+	"testing"
+
+	v1Client "github.com/roadrunner-server/api-go/v6/centrifugo/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCBatchNotReady(t *testing.T) {
+	// client() returns nil until connect() succeeds, so Batch returns early.
+	r := &rpc{client: &client{}, log: testLogger()}
+
+	err := r.Batch(&v1Client.BatchRequest{}, &v1Client.BatchResponse{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RoadRunner is not ready yet")
+}

--- a/status.go
+++ b/status.go
@@ -12,10 +12,14 @@ func (p *Plugin) Status() (*status.Status, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
+	if p.pool == nil {
+		return &status.Status{Code: http.StatusServiceUnavailable}, nil
+	}
+
 	workers := p.pool.Workers()
 
-	for i := range workers {
-		if workers[i].State().IsActive() {
+	for _, w := range workers {
+		if w.State().IsActive() {
 			return &status.Status{
 				Code: http.StatusOK,
 			}, nil
@@ -32,12 +36,16 @@ func (p *Plugin) Ready() (*status.Status, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
+	if p.pool == nil {
+		return &status.Status{Code: http.StatusServiceUnavailable}, nil
+	}
+
 	workers := p.pool.Workers()
 
-	for i := range workers {
+	for _, w := range workers {
 		// If state of the worker is ready (at least 1)
 		// we assume, that plugin's worker pool is ready
-		if workers[i].State().Compare(fsm.StateReady) {
+		if w.State().Compare(fsm.StateReady) {
 			return &status.Status{
 				Code: http.StatusOK,
 			}, nil

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,25 @@
+package centrifuge
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginStatusNilPool(t *testing.T) {
+	p := &Plugin{}
+
+	st, err := p.Status()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, st.Code)
+}
+
+func TestPluginReadyNilPool(t *testing.T) {
+	p := &Plugin{}
+
+	st, err := p.Ready()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, st.Code)
+}


### PR DESCRIPTION
## Summary

- **proxy.go** (R/High): guard all 8 `FromIncomingContext` calls with the two-value form; initialize `metadata.New(nil)` when no incoming metadata is present — the discarded-ok pattern left `md` as a nil map, causing `md.Append(...)` to panic on every unauthenticated gRPC call
- **plugin.go** (R/High): nil-guard `p.pool` before `Destroy` in `Stop` — pool is nil if `Serve` returned early (e.g. listener creation failed)
- **status.go** (R/Med): nil-guard `p.pool` in `Status` and `Ready` before calling `Workers`; apply value-range loop (`for _, w := range`)
- **config.go** (R/Low + M/Low): replace manual `len > 7 && addr[0:6] == "tcp://"` strip with `strings.CutPrefix` (off-by-one skipped exactly-7-char addresses like `tcp://x`); `os.IsNotExist` → `errors.Is(err, os.ErrNotExist)`
- **rpc.go** (R/Low): fix log typo `"got butch request"` → `"got batch request"`
- **plugin.go** (S/Low): annotate bare `// nosemgrep` with rule id; value-range workers loop
- **metrics.go** (S/Low): `for i := range workerStates` → `for _, ws := range workerStates`

